### PR TITLE
chore: use module-builder stub mode for more accurate types

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,0 @@
-typescript.includeWorkspace=true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepack": "nuxt-module-build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test:types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build",
+    "prepack": "nuxt-module-build build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test:types": "tsc --noEmit",

--- a/src/module.ts
+++ b/src/module.ts
@@ -82,7 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Add module options to public runtime config
     nuxt.options.runtimeConfig.public.plausible = defu(
-      nuxt.options.runtimeConfig.public.plausible,
+      nuxt.options.runtimeConfig.public.plausible as ModuleOptions,
       options,
     )
 

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,8 +1,9 @@
 import Plausible from 'plausible-tracker'
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
+import type { ModuleOptions } from '../module'
 
 export default defineNuxtPlugin(() => {
-  const { plausible: options } = useRuntimeConfig().public
+  const options = useRuntimeConfig().public.plausible as ModuleOptions
 
   const plausible = Plausible({
     ...options,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
We added a `prepare` command for nuxt-module-build which allows creating type stubs directly from the module without needing to apply to the playground as well. (https://github.com/nuxt/module-builder/pull/124)

It's the default for new modules (https://github.com/nuxt/starter/pull/392).

This should allow us to match types more appropriately for module authors (for example, disallowing auto-imports) in future.