### PR TITLE
feat: API event handler to proxy `event` through Nitro server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ With this setup, you can omit the `plausible` key in your Nuxt configuration.
 | `autoPageviews`        | `boolean`  | `true`                       | Track the current page and all further pages automatically. Disable this if you want to manually manage pageview tracking.                                                                                                                      |
 | `autoOutboundTracking` | `boolean`  | `false`                      | Track all outbound link clicks automatically. If enabled, a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) automagically detects link nodes throughout the application and binds `click` events to them. |
 | `logIgnoredEvents`     | `boolean`  | `false`                      | Log events to the console if they are ignored.                                                                                                                                                                                                  |
+| `proxy`                | `boolean`  | `false`                      | Whether to proxy the event endpoint through the current origin.                                                                                                                                                                                 |
+| `proxyBaseURL`         | `string`   | `'/api/event'`               | The base URL to proxy the event endpoint through.                                                                                                                                                                                               |
 
 ## Composables
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,5 +6,6 @@ export default defineNuxtConfig({
   plausible: {
     autoPageviews: false,
     autoOutboundTracking: false,
+    proxy: true,
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -166,12 +166,12 @@ export default defineNuxtModule<ModuleOptions>({
         = nuxt.options.serverHandlers.find(handler => handler.route?.startsWith(proxyBaseURL))
         || nuxt.options.devServerHandlers.find(handler => handler.route?.startsWith(proxyBaseURL))
       if (hasUserProvidedProxyBaseURL) {
-        throw new Error(`The route ${proxyBaseURL} is already in use. Please use the 'proxyBaseURL' option to change the base URL of the proxy endpoint.`)
+        throw new Error(`The route \`${proxyBaseURL}\` is already in use. Please use the \`proxyBaseURL\` option to change the base URL of the proxy endpoint.`)
       }
 
       addServerHandler({
         route: proxyBaseURL,
-        handler: resolve('./runtime/server/api/event.post'),
+        handler: resolve('runtime/server/api/event.post'),
         method: 'post',
       })
     }

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -17,6 +17,7 @@ export default defineNuxtPlugin({
       ...options,
       logIgnored: options.logIgnoredEvents,
       domain: options.domain || window.location.hostname,
+      apiHost: options.proxy ? window.location.origin : options.apiHost,
     })
 
     return {

--- a/src/runtime/server/api/event.post.ts
+++ b/src/runtime/server/api/event.post.ts
@@ -1,0 +1,54 @@
+import { createError, defineEventHandler, getHeaders, getRequestIP, readBody } from 'h3'
+import { ofetch } from 'ofetch'
+import { withoutTrailingSlash } from 'ufo'
+import type { ModuleOptions } from '../../../module'
+import { useRuntimeConfig } from '#imports'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const config = useRuntimeConfig(event)
+    const options = config.public.plausible as Required<ModuleOptions>
+
+    if (!options?.apiHost) {
+      throw createError({
+        statusCode: 500,
+        message: 'Plausible API host not configured',
+      })
+    }
+
+    const target = `${withoutTrailingSlash(options.apiHost)}/api/event`
+
+    const body = await readBody(event)
+
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      ...Object.fromEntries([
+        ['User-Agent', getHeaders(event)['user-agent']],
+        ['X-Forwarded-For', getRequestIP(event, { xForwardedFor: true })],
+      ].filter(([_, value]) => value != null)),
+    })
+
+    const result = await ofetch(target, {
+      method: 'POST',
+      headers: headers,
+      body,
+      retry: 2,
+      timeout: 5000,
+      onRequestError: ({ request, error }) => {
+        console.error(`Failed to send request to ${request}: ${error.message}`)
+      },
+    })
+
+    return result
+  }
+  catch (error) {
+    if (error instanceof Error && error.name === 'FetchError') {
+      throw createError({
+        statusCode: 502,
+        message: 'Failed to reach Plausible analytics service',
+      })
+    }
+
+    throw error
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #34

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR implements proxy functionality for Plausible analytics events, allowing events to be proxied through the Nitro server instead of being sent directly to Plausible's servers. While the original issue suggested using Nitro route rules, this implementation uses a custom server handler for more control over the proxying process and better error handling.

Rather than relying on the Plausible script and its `data-api` attribute, this solution works with the `@barbapapazes/plausible-tracker` package that's bundled with the module. When proxy is enabled, the tracker automatically routes requests through the current origin.

Key changes:
- Added new configuration options:
  - `proxy`: Toggle to enable/disable proxy functionality (default: false)
  - `proxyBaseURL`: Customizable base URL for the proxy endpoint (default: '/api/event')
- Implemented server-side event handler that forwards requests to Plausible while preserving important headers
- Updated client-side plugin to automatically use the correct endpoint based on proxy configuration
- Added validation to prevent route conflicts
- Enhanced error handling with appropriate status codes and messages
- Updated documentation with new configuration options

Example usage:
```ts
// nuxt.config.ts
export default defineNuxtConfig({
  plausible: {
    proxy: true, // Enable proxying through Nitro server
    proxyBaseURL: '/api/event', // Optional: customize the proxy endpoint
  }
})
```